### PR TITLE
script to install just guacamole-server + version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # guac-install
-Script for installing Guacamole 0.9.11 on Ubuntu 16.04 with MySQL
+Script for installing Guacamole 0.9.12 on Ubuntu 16.04 with MySQL
 
-Run script, enter MySQL Root Password and Guacample User password. Guacamole User is used to connect the the Guacamole Database.
+Run script, enter MySQL Root Password and Guacamole User password. Guacamole User is used to connect the the Guacamole Database.
 
 How to Run:
 

--- a/docker-install.sh
+++ b/docker-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # WORKING ON UBUNTU 16.04 LTS
 
-VERSION="0.9.11"
+VERSION="0.9.12"
 SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')
 
 read -s -p "Enter the password that will be used for MySQL Root: " MYSQLROOTPASSWORD

--- a/guac-install-server.sh
+++ b/guac-install-server.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+VERSION="0.9.12"
+
+# Install Server Features
+apt-get update
+apt-get -y install build-essential libcairo2-dev libjpeg-turbo8-dev libpng12-dev libossp-uuid-dev libavcodec-dev libavutil-dev \
+libswscale-dev libfreerdp-dev libpango1.0-dev libssh2-1-dev libtelnet-dev libvncserver-dev libpulse-dev libssl-dev \
+libvorbis-dev libwebp-dev jq
+
+# If Apt-Get fails to run completely the rest of this isn't going to work...
+if [ $? != 0 ]
+then
+    echo "apt-get failed to install all required dependencies. Are you on Ubuntu 16.04 LTS?"
+    exit
+fi
+
+SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')
+
+# Download Guacample Files
+wget ${SERVER}/incubator/guacamole/${VERSION}-incubating/source/guacamole-server-${VERSION}-incubating.tar.gz
+
+# Extract Guacamole Files
+tar -xzf guacamole-server-${VERSION}-incubating.tar.gz
+
+# MAKE DIRECTORIES
+mkdir /etc/guacamole
+
+# Install GUACD
+cd guacamole-server-${VERSION}-incubating
+./configure --with-init-dir=/etc/init.d
+make
+make install
+ldconfig
+cd ..
+
+# Configure guacamole.properties
+echo "[server]" >> /etc/guacamole/guacd.conf
+echo "bind_host = 0.0.0.0" >> /etc/guacamole/guacd.conf
+echo "bind_port = 4822" >> /etc/guacamole/guacd.conf
+
+# Configure startup
+systemctl enable guacd
+systemctl start guacd
+
+# Cleanup
+rm -rf guacamole-*

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 VERSION="0.9.11"
-SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')
 
 # Grab a password for MySQL Root
 read -s -p "Enter the password that will be used for MySQL Root: " mysqlrootpassword
@@ -23,6 +22,8 @@ then
     echo "apt-get failed to install all required dependencies. Are you on Ubuntu 16.04 LTS?"
     exit
 fi
+
+SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')
 
 # Add GUACAMOLE_HOME to Tomcat8 ENV
 echo "" >> /etc/default/tomcat8

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.9.11"
+VERSION="0.9.12"
 
 # Grab a password for MySQL Root
 read -s -p "Enter the password that will be used for MySQL Root: " mysqlrootpassword

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -1,4 +1,4 @@
-VERSION="0.9.11"
+VERSION="0.9.12"
 SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')
 
 # Stop Tomcat


### PR DESCRIPTION
created a new script to install just the server portion of Guacamole, in order to be used on a Cloud provider. This script can be hooked as a startup script of a new VM (takes about 2 minutes to complete) or just ran as 1 time to create a template to be used for further deployments.
Server will be configured to allow connections from anywhere (0.0.0.0), delegating restriction of access to firewall on Cloud provider.