### PR TITLE
0.9.13 update

### DIFF
--- a/docker-install.sh
+++ b/docker-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # WORKING ON UBUNTU 16.04 LTS
 
-VERSION="0.9.12"
+VERSION="0.9.13"
 
 read -s -p "Enter the password that will be used for MySQL Root: " MYSQLROOTPASSWORD
 read -s -p "Enter the password that will be used for the Guacamole database: " GUACDBUSERPASSWORD

--- a/guac-install-server.sh
+++ b/guac-install-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.9.12"
+VERSION="0.9.13"
 
 # Ubuntu and Debian have different names of the libjpeg-turbo library for some reason...
 if [ `egrep -c "ID=ubuntu" /etc/os-release` -gt 0 ]

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Version Numbers of Guacamole and MySQL Connection/J to download
-VERSION="0.9.12"
+VERSION="0.9.13"
 MCJVERSION="5.1.43"
 
 # Grab a password for MySQL Root

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -1,5 +1,5 @@
 # Version Numbers of Guacamole and MySQL Connection/J to download
-VERSION="0.9.12"
+VERSION="0.9.13"
 MCJVERSION = "5.1.43"
 
 SERVER=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | jq --raw-output '.preferred|rtrimstr("/")')


### PR DESCRIPTION
Per Mike Jumper on the official website github pull request to release 0.9.13:

> We'll still need to hold off on actually deploying these changes until 2017-08-01 00:01 -0700, as that will be 24 hours since the release artifacts were deployed (and the mirrors need roughly 24 hours to sync). From http://www.apache.org/dev/release.html#release-announcements: