### PR TITLE
change the old architecture check

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -35,8 +35,8 @@ else
     JPEGTURBO="libjpeg62-turbo-dev"
 fi
 
-# Get architecture - 32 bit or 64 bit
-if [ $(getconf LONG_BIT | grep 64) ]; then ARCH="x86_64";  else ARCH="i386"; fi
+# Get build-folder
+BUILD_FOLDER=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 
 # Install Features
 apt-get -y install build-essential libcairo2-dev ${JPEGTURBO} libpng12-dev libossp-uuid-dev libavcodec-dev libavutil-dev \
@@ -84,7 +84,7 @@ cd ..
 # Move files to correct locations
 mv guacamole-${VERSION}-incubating.war /etc/guacamole/guacamole.war
 ln -s /etc/guacamole/guacamole.war /var/lib/${TOMCAT}/webapps/
-ln -s /usr/local/lib/freerdp/* /usr/lib/$ARCH-linux-gnu/freerdp/.
+ln -s /usr/local/lib/freerdp/guac*.so /usr/lib/$BUILD_FOLDER/freerdp/
 cp mysql-connector-java-${MCJVERSION}/mysql-connector-java-${MCJVERSION}-bin.jar /etc/guacamole/lib/
 cp guacamole-auth-jdbc-${VERSION}-incubating/mysql/guacamole-auth-jdbc-mysql-${VERSION}-incubating.jar /etc/guacamole/extensions/
 


### PR DESCRIPTION
The old Version does not work perfect on some arm-systems. As example:

The corect FreeRDP path on an PI is `/usr/lib/arm-linux-gnueabihf/freerdp/`. But 

The old version just covers `/usr/lib/x86_64-linux-gnu/freerdp/` and `/usr/lib/i386-linux-gnu/freerdp/`. The new version should cover any possible case.

It also tweak the `ln` a bit. Because not all files need to be linked. Just the `guac*.so`