### PR TITLE
Switch to libmysql-java

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -111,18 +111,9 @@ if [ $? -ne 0 ]; then
     exit
 fi
 
-# Download MySQL Connector-J
-wget -O mysql-connector-java-${MCJVERSION}.tar.gz https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MCJVERSION}.tar.gz
-if [ $? -ne 0 ]; then
-    echo "Failed to download mysql-connector-java-${MCJVERSION}.tar.gz"
-    echo "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MCJVERSION}.tar.gz"
-    exit
-fi
-
 # Extract Guacamole files
 tar -xzf guacamole-server-${GUACVERSION}.tar.gz
 tar -xzf guacamole-auth-jdbc-${GUACVERSION}.tar.gz
-tar -xzf mysql-connector-java-${MCJVERSION}.tar.gz
 
 # Make directories
 mkdir -p /etc/guacamole/lib
@@ -177,6 +168,5 @@ service guacd start
 
 # Cleanup
 rm -rf guacamole-*
-rm -rf mysql-connector-java-${MCJVERSION}*
 
 echo -e "Installation Complete\nhttp://localhost:8080/guacamole/\nDefault login guacadmin:guacadmin\nBe sure to change the password."

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -2,7 +2,6 @@
 
 # Version numbers of Guacamole and MySQL Connector/J to download
 GUACVERSION="0.9.14"
-MCJVERSION="5.1.45"
 
 # Update apt so we can search apt-cache for newest tomcat version supported
 apt update
@@ -76,7 +75,8 @@ fi
 # Install features
 apt -y install build-essential libcairo2-dev ${JPEGTURBO} ${LIBPNG} libossp-uuid-dev libavcodec-dev libavutil-dev \
 libswscale-dev libfreerdp-dev libpango1.0-dev libssh2-1-dev libtelnet-dev libvncserver-dev libpulse-dev libssl-dev \
-libvorbis-dev libwebp-dev mysql-server mysql-client mysql-common mysql-utilities ${TOMCAT} freerdp-x11 ghostscript wget dpkg-dev
+libvorbis-dev libwebp-dev mysql-server mysql-client mysql-common mysql-utilities libmysql-java ${TOMCAT} freerdp-x11 \
+ghostscript wget dpkg-dev
 
 # If apt fails to run completely the rest of this isn't going to work...
 if [ $? -ne 0 ]; then
@@ -144,7 +144,7 @@ BUILD_FOLDER=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 mv guacamole-${GUACVERSION}.war /etc/guacamole/guacamole.war
 ln -s /etc/guacamole/guacamole.war /var/lib/${TOMCAT}/webapps/
 ln -s /usr/local/lib/freerdp/guac*.so /usr/lib/${BUILD_FOLDER}/freerdp/
-cp mysql-connector-java-${MCJVERSION}/mysql-connector-java-${MCJVERSION}-bin.jar /etc/guacamole/lib/
+ln -s /usr/share/java/mysql-connector-java.jar /etc/guacamole/lib/
 cp guacamole-auth-jdbc-${GUACVERSION}/mysql/guacamole-auth-jdbc-mysql-${GUACVERSION}.jar /etc/guacamole/extensions/
 
 # Configure guacamole.properties

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -17,7 +17,6 @@ echo
 
 # Version Numbers of Guacamole and MySQL Connector/J to download
 GUACVERSION="0.9.14"
-MCJVERSION="5.1.45"
 
 # Get Tomcat Version
 TOMCAT=$(ls /etc/ | grep tomcat)
@@ -55,14 +54,6 @@ if [ $? -ne 0 ]; then
     exit
 fi
 
-# Download the MySQL Connector/J
-wget -O mysql-connector-java-${MCJVERSION}.tar.gz https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MCJVERSION}.tar.gz
-if [ $? -ne 0 ]; then
-    echo "Failed to download mysql-connector-java-${MCJVERSION}.tar.gz"
-    echo "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MCJVERSION}.tar.gz"
-    exit
-fi
-
 # Upgrade Guacamole Server
 tar -xzf guacamole-server-${GUACVERSION}.tar.gz
 cd guacamole-server-${GUACVERSION}
@@ -79,9 +70,6 @@ mv guacamole-${GUACVERSION}.war /etc/guacamole/guacamole.war
 # Upgrade SQL Components
 tar -xzf guacamole-auth-jdbc-${GUACVERSION}.tar.gz
 cp guacamole-auth-jdbc-${GUACVERSION}/mysql/guacamole-auth-jdbc-mysql-${GUACVERSION}.jar /etc/guacamole/extensions/
-tar -xzf mysql-connector-java-${MCJVERSION}.tar.gz
-cp mysql-connector-java-${MCJVERSION}/mysql-connector-java-${MCJVERSION}-bin.jar /etc/guacamole/lib/
-rm -rf mysql-connector-java-${MCJVERSION}*
 
 # Get list of SQL Upgrade Files
 UPGRADEFILES=($(ls -1 guacamole-auth-jdbc-${GUACVERSION}/mysql/schema/upgrade/ | sort -V))


### PR DESCRIPTION
Switch to libmysql-java - After checking Ubuntu and Debian this appears to be universal and should work for both and for any version of release.

Closes #30 suggested by @MysticEmpires 