### PR TITLE
Add Optional MySQL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
+
+
 # guac-install
 
-Script for installing Guacamole 1.1.0 on Ubuntu 16.04 or newer with MySQL. It should also work on pure Debian 7, 8, and 9. **It seems Debian 10 is not working right now**
+Script for installing Guacamole 1.1.0 on Ubuntu 16.04 or newer (optionally with MySQL by default). It should also work on pure Debian 7, 8, and 9. **It seems Debian 10 is not working right now**
 
 Run script, enter MySQL Root Password and Guacamole User password. Guacamole User is used to connect to the Guacamole Database.
 
-The script attempts to install tomcat8 if the available version is 8.5.x or newer, if tomcat8 is only 8.0.x it will fall back to tomcat7. If you want to manually specify a tomcat version there's a commented out line you can modify at line #73. Have at it.
+The script attempts to install tomcat8 if the available version is 8.5.x or newer, if tomcat8 is only 8.0.x it will fall back to tomcat7. If you want to manually specify a tomcat version there's a commented out line you can modify. Have at it.
 
 If you're looking to also have NGINX / Let's Encrypt / HTTPS click [HERE](https://github.com/bigredthelogger/guacamole)
 
 ## MFA/2FA
 
-By default the script will not install MFA support (QR code for Google/Microsoft Authenticator, Duo Mobile, etc. or Duo Push), if you do want MFA support you need to specify the `-t` or `--totp` or for Duo `-o` or `--duo` flags on the command line. Or modify the script variable `installTOTP=true` or `installDuo=true`
+By default the script will not install MFA support (QR code for Google/Microsoft Authenticator, Duo Mobile, etc. or Duo Push), if you do want MFA support you need to specify the `-t` or `--totp` or for Duo `-d` or `--duo` flags on the command line. Or modify the script variables `installTOTP=true` or `installDuo=true`.
 
 ## How to Run:
 
@@ -28,26 +30,59 @@ Interactive (asks for passwords):
 
 <code>./guac-install.sh</code>
 
-Non-Interactive (passwords provided via cli):
+Non-Interactive (values provided via cli):
 
 <code>./guac-install.sh --mysqlpwd password --guacpwd password</code>
 
 OR
 
-<code>./guac-install.sh -m password -g password</code>
+<code>./guac-install.sh -r password -gp password</code>
 
-Once installation is done you can access guacamole by browsing to: http://<host_or_ip>:8080/guacamole/
+Once installation is done you can access Guacamole by browsing to: http://<host_or_ip>:8080/guacamole/
 The default credentials are guacadmin as both username and password. Please change them or disable guacadmin after install!
 
 # guac-upgrade
-Script for upgrading currently installed Guacamole instance (previously installed via this script/guide)
+Script for upgrading currently installed Guacamole instance (previously installed via this script/guide).  This will also now update the TOTP or Duo extensions if used.
 
 
 If looks for the tomcat folder in /etc/ (E.G. `/etc/tomcat7` or `/etc/tomcat8`) hopefully that works to identify the correct tomcat version/path :smile: I'm open to suggestions/pull requests for a cleaner method.
 
+## All Switches
+
+Install MySQL:
+<code>-i or --installmysql</code>
+
+Do *NOT* install MySQL:
+<code>-n or --nomysql</code>
+
+MySQL Host:
+<code>-h or --mysqlhost</code>
+
+MySQL Port:
+<code>-p or --mysqlport</code>
+
+MySQL Root Password:
+<code>-r or --mysqlpwd</code>
+
+Guacamole Database:
+<code>-db or --guacdb</code>
+
+Guacamole User:
+<code>-gu or --guacuser</code>
+
+Guacamole User Password:
+<code>-gp or --guacpwd</code>
+
+Install TOTP:
+<code>-t or --totp</code>
+
+Install Duo:
+<code>-d or --duo</code>
+
 ## WARNING
 
-I don't think this script is working anymore. Way too many reports that 0.9.14 -> 1.0.0 are not working. I don't know why.
+- Upgrading from 0.9.14 -> 1.1.0 has not been tested, only 1.0.0 -> 1.1.0.
+- Switches have changed and additional ones have been added!
 
 ## How to Run:
 
@@ -65,6 +100,6 @@ Interactive (asks for passwords):
 
 <code>./guac-upgrade.sh</code>
 
-Non-Interactive (password provided via cli):
+Non-Interactive (MySQL root password provided via cli):
 
 <code>./guac-upgrade.sh --mysqlpwd password</code>

--- a/README.md
+++ b/README.md
@@ -50,33 +50,43 @@ If looks for the tomcat folder in /etc/ (E.G. `/etc/tomcat7` or `/etc/tomcat8`) 
 ## All Switches
 
 Install MySQL:
+
 <code>-i or --installmysql</code>
 
 Do *NOT* install MySQL:
+
 <code>-n or --nomysql</code>
 
 MySQL Host:
+
 <code>-h or --mysqlhost</code>
 
 MySQL Port:
+
 <code>-p or --mysqlport</code>
 
 MySQL Root Password:
+
 <code>-r or --mysqlpwd</code>
 
 Guacamole Database:
+
 <code>-db or --guacdb</code>
 
 Guacamole User:
+
 <code>-gu or --guacuser</code>
 
 Guacamole User Password:
+
 <code>-gp or --guacpwd</code>
 
 Install TOTP:
+
 <code>-t or --totp</code>
 
 Install Duo:
+
 <code>-d or --duo</code>
 
 ## WARNING

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Install Duo:
 
 <code>-d or --duo</code>
 
-NOTE: Only the switches for MySQL Host and Guacamole Database are available in the upgrade script.
+NOTE: Only the switches for MySQL Host, MySQL Port and Guacamole Database are available in the upgrade script.
 
 ## WARNING
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Install Duo:
 
 <code>-d or --duo</code>
 
+NOTE: Only the switches for MySQL Host and Guacamole Database are available in the upgrade script.
+
 ## WARNING
 
 - Upgrading from 0.9.14 -> 1.1.0 has not been tested, only 1.0.0 -> 1.1.0.

--- a/guac-install-server.sh
+++ b/guac-install-server.sh
@@ -32,7 +32,7 @@ fi
 apt update
 apt -y install build-essential libcairo2-dev ${JPEGTURBO} ${LIBPNG} libossp-uuid-dev libavcodec-dev libavutil-dev \
 libswscale-dev freerdp2-dev libpango1.0-dev libssh2-1-dev libtelnet-dev libvncserver-dev libpulse-dev libssl-dev \
-libvorbis-dev libwebp-dev jq curl wget libtool-bin
+libvorbis-dev libwebp-dev jq curl wget libtool-bin libwebsockets-dev
 
 # If apt fails to run completely the rest of this isn't going to work...
 if [ $? != 0 ]

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -24,7 +24,6 @@ installDuo=""
 installMySQL=""
 mysqlHost=""
 mysqlPort=""
-mysqlRootUser=""
 mysqlRootPwd=""
 
 guacDb=""
@@ -53,11 +52,7 @@ while [ "$1" != "" ]; do
             shift
             mysqlPort="$1"
             ;;
-        -ru | --mysqluser )
-            shift
-            mysqlRootUser="$1"
-            ;;
-        -rp | --mysqlpwd )
+        -r | --mysqlpwd )
             shift
             mysqlRootPwd="$1"
             ;;
@@ -159,8 +154,8 @@ if [ -z "$mysqlPort" ]; then
 fi
 
 # Checking if mysql user given
-if [ -z "$mysqlRootUser" ]; then
-    mysqlRootUser="guacamole_user"
+if [ -z "$guacUser" ]; then
+    guacUser="guacamole_user"
 fi
 
 # Checking if database name given
@@ -384,7 +379,7 @@ else
     echo -e "${GREEN}OK${NC}"
 fi
 
-# Create guacamole_db and grant $mysqlRootUser permissions to it
+# Create guacamole_db and grant $guacUser permissions to it
 
 # SQL code
 SQLCODE="

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -380,7 +380,7 @@ fi
 # SQL code
 guacUserHost="localhost"
 
-if [ ! "$mysqlHost" = "localhost"]; then
+if [[ "$mysqlHost" != "localhost" ]]; then
     guacUserHost="%"
     echo -e "${YELLOW}MySQL Guacamole user is set to accept login from any host, please change this for security reasons if possible.${NC}"
 fi
@@ -391,12 +391,14 @@ create user if not exists '${guacUser}'@'${guacUserHost}' identified by \"${guac
 GRANT SELECT,INSERT,UPDATE,DELETE ON ${guacDb}.* TO '${guacUser}'@'${guacUserHost}';
 flush privileges;"
 
+export MYSQL_PWD=${mysqlRootPwd}
+
 # Execute SQL code
-echo ${SQLCODE} | mysql -u root -p${mysqlRootPwd} -h ${mysqlHost} -P ${mysqlPort}
+echo ${SQLCODE} | mysql -u root -h ${mysqlHost} -P ${mysqlPort}
 
 # Add Guacamole schema to newly created database
 echo -e "Adding db tables..."
-cat guacamole-auth-jdbc-${GUACVERSION}/mysql/schema/*.sql | mysql -u root -p${mysqlRootPwd} ${guacDb} -h ${mysqlHost} -P ${mysqlPort}
+cat guacamole-auth-jdbc-${GUACVERSION}/mysql/schema/*.sql | mysql -u root -D ${guacDb} -h ${mysqlHost} -P ${mysqlPort}
 if [ $? -ne 0 ]; then
     echo -e "${RED}Failed${NC}"
     exit 1
@@ -418,5 +420,6 @@ if [ $? -ne 0 ]; then
 else
     echo -e "${GREEN}OK${NC}"
 fi
+unset MYSQL_PWD
 
 echo -e "${BLUE}Installation Complete\nhttp://localhost:8080/guacamole/\nDefault login guacadmin:guacadmin\nBe sure to change the password.${NC}"

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -20,18 +20,33 @@ LOG="/tmp/guacamole_${GUACVERSION}_build.log"
 # Default : Do not install TOTP/Duo
 installTOTP=false
 installDuo=false
+installMySQL=true
 
 # Prompt the user if they would like to install MFA, default of no
 PROMPT=""
-echo -e -n "${CYAN}(!)${NC} Do you want to use TOTP? (y/N): "
+echo -e -n "${CYAN}(!)${NC} Would you like to install TOTP? (y/N): "
 read PROMPT
 echo ""
 if [[ $PROMPT =~ ^[Yy]$ ]]; then installTOTP=true; fi
 
-echo -e -n "${CYAN}(!)${NC} Do you want to use Duo? (y/N): "
+echo -e -n "${CYAN}(!)${NC} Would you like to install Duo (configuration values must be set after install in guacamole.properties)? (y/N): "
 read PROMPT
 echo ""
 if [[ $PROMPT =~ ^[Yy]$ ]]; then installDuo=true; fi
+
+# Prompt the user to see if they would like to install MySQL, default of yes
+echo -e -n "${CYAN}(!)${NC} Would you like to install MySQL? (Y/n): "
+read PROMPT
+echo ""
+if [[ $PROMPT =~ ^[Nn]$ ]] || [[ "$PROMPT" == "no" ]]; then installMySQL=false; fi
+
+if [ "$installMySQL" = true ]; then
+    echo "Installing MySQL!"
+else
+    echo "Not installing MySQL!"
+fi
+
+exit 1
 
 # Get script arguments for non-interactive mode
 while [ "$1" != "" ]; do

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -336,6 +336,7 @@ BUILD_FOLDER=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 # Move files to correct locations
 mv guacamole-${GUACVERSION}.war /etc/guacamole/guacamole.war
 ln -s /etc/guacamole/guacamole.war /var/lib/${TOMCAT}/webapps/
+ln -s /usr/local/lib/freerdp/guac*.so /usr/lib/${BUILD_FOLDER}/freerdp/
 ln -s /usr/share/java/mysql-connector-java.jar /etc/guacamole/lib/
 cp guacamole-auth-jdbc-${GUACVERSION}/mysql/guacamole-auth-jdbc-mysql-${GUACVERSION}.jar /etc/guacamole/extensions/
 

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -336,7 +336,6 @@ BUILD_FOLDER=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 # Move files to correct locations
 mv guacamole-${GUACVERSION}.war /etc/guacamole/guacamole.war
 ln -s /etc/guacamole/guacamole.war /var/lib/${TOMCAT}/webapps/
-ln -s /usr/local/lib/freerdp/guac*.so /usr/lib/${BUILD_FOLDER}/freerdp/
 ln -s /usr/share/java/mysql-connector-java.jar /etc/guacamole/lib/
 cp guacamole-auth-jdbc-${GUACVERSION}/mysql/guacamole-auth-jdbc-mysql-${GUACVERSION}.jar /etc/guacamole/extensions/
 
@@ -381,7 +380,7 @@ fi
 # SQL code
 guacUserHost="localhost"
 
-if [ ! "$mysqlHost" = "localhost"]
+if [ ! "$mysqlHost" = "localhost"]; then
     guacUserHost="%"
     echo -e "${YELLOW}MySQL Guacamole user is set to accept login from any host, please change this for security reasons if possible.${NC}"
 fi

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -295,18 +295,13 @@ echo "mysql-database: ${DB}" >> /etc/guacamole/guacamole.properties
 echo "mysql-username: ${mysqluser}" >> /etc/guacamole/guacamole.properties
 echo "mysql-password: ${guacdbuserpassword}" >> /etc/guacamole/guacamole.properties
 
+# Output Duo configuration settings but comment them out for now
+echo "# duo-api-hostname: <value>" >> /etc/guacamole/guacamole.properties
+echo "# duo-integration-key: <value>" >> /etc/guacamole/guacamole.properties
+echo "# duo-secret-key: <value>" >> /etc/guacamole/guacamole.properties
+echo "# duo-application-key: <value>" >> /etc/guacamole/guacamole.properties
 if [ "$installDuo" = true ]; then
-    echo "duo-api-hostname: <value>" >> /etc/guacamole/guacamole.properties
-    echo "duo-integration-key: <value>" >> /etc/guacamole/guacamole.properties
-    echo "duo-secret-key: <value>" >> /etc/guacamole/guacamole.properties
-    echo "duo-application-key: <value>" >> /etc/guacamole/guacamole.properties
     echo -e "${BLUE}Duo is installed, it will need to be configured via guacamole.properties!${NC}"
-else
-    # Still output the values, but comment them out
-    echo "# duo-api-hostname: <value>" >> /etc/guacamole/guacamole.properties
-    echo "# duo-integration-key: <value>" >> /etc/guacamole/guacamole.properties
-    echo "# duo-secret-key: <value>" >> /etc/guacamole/guacamole.properties
-    echo "# duo-application-key: <value>" >> /etc/guacamole/guacamole.properties
 fi
 
 # restart tomcat

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -36,10 +36,10 @@ PROMPT=""
 while [ "$1" != "" ]; do
     case $1 in
         # Install MySQL selection
-        -m | --installmysql )
+        -i | --installmysql )
             installMySQL=true
             ;;
-        -nm | --nomysql )
+        -n | --nomysql )
             installMySQL=false
             ;;
 

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -193,6 +193,7 @@ for file in /etc/guacamole/extensions/guacamole-auth-duo*.jar; do
 done
 
 # Start tomcat and Guacamole
+echo -e "${BLUE}Starting tomcat and guacamole...${NC}"
 service ${TOMCAT} start
 service guacd start
 

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -56,18 +56,18 @@ if [ -z "$mysqlPort" ]; then
     fi
 fi
 
-# Get MySQL root password
 if [ -n "$mysqlRootPwd" ]; then
     export MYSQL_PWD=${mysqlRootPwd}
-    mysql -u root -h ${mysqlHost} ${guacDb} -e"quit" || exit
+    mysql -u root -D ${guacDb} -h ${mysqlHost} -P ${mysqlPort} -e"quit" || exit
 else
+    # Get MySQL root password
     echo
     while true
     do
         read -s -p "Enter MySQL ROOT Password: " mysqlRootPwd
         export MYSQL_PWD=${mysqlRootPwd}
         echo
-        mysql -u root -h ${mysqlHost} ${guacDb} -e"quit" && break
+        mysql -u root -D ${guacDb} -h ${mysqlHost} -P ${mysqlPort} -e"quit" && break
         echo
     done
     echo


### PR DESCRIPTION
Added support to make the install of MySQL optional and revamped the command line variable usage.  Now only prompts for various values if they were not set via command line, etc.  Fixed missing package from guac-install-server.sh as well.