### PR TITLE
Fix mysql password error

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -510,6 +510,9 @@ systemctl enable ${TOMCAT}
 echo
 
 if [ "${installMySQL}" = true ]; then
+    # Set MySQL password
+    export MYSQL_PWD=${mysqlRootPwd}
+
     # Restart MySQL service
     echo -e "${BLUE}Restarting MySQL service & enable at boot...${NC}"
     service mysql restart
@@ -571,9 +574,6 @@ if [[ "${mysqlHost}" != "localhost" ]]; then
     guacUserHost="%"
     echo -e "${YELLOW}MySQL Guacamole user is set to accept login from any host, please change this for security reasons if possible.${NC}"
 fi
-
-# Set MySQL password
-export MYSQL_PWD=${mysqlRootPwd}
 
 # Check for ${guacDb} already being there
 echo -e "${BLUE}Checking MySQL for existing database (${guacDb})${NC}"

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -509,9 +509,10 @@ fi
 systemctl enable ${TOMCAT}
 echo
 
+# Set MySQL password
+export MYSQL_PWD=${mysqlRootPwd}
+
 if [ "${installMySQL}" = true ]; then
-    # Set MySQL password
-    export MYSQL_PWD=${mysqlRootPwd}
 
     # Restart MySQL service
     echo -e "${BLUE}Restarting MySQL service & enable at boot...${NC}"


### PR DESCRIPTION
The script fails when run in Ubuntu 19.10. MySQL fails to restart after the timezone is changed because the MySQL password is not defined. (The script passes in Ubuntu 18.04)

The script sets the MySQL password after it calls the MySQL command to change the timezone so the timezone change fails. This causes the script to fail when it is run in Ubuntu 19.10. I moved the statement that sets the password to a place where it sets the password before any MySQL commands are run.

I tested the change in both Ubuntu 19.10 and Ubuntu 18.04.
