### PR TITLE
Updated to support guacamole 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # guac-install
 
-I've maintained this script for quite a few years now with the help of the other contributors and it seems to be getting more and more fragmented as libraries and system OSes diverge in their package management. I plan to continue maintaining the install script, but, I do highly suggest that more people try to use the containerized (docker) version. As it should work on basically any 64bit OS with Docker support. (That means it doesn't work on 32bit ARM/Rasp Pi)
+I've maintained this script for quite a few years now with the help of the other contributors and it seems to be getting more and more fragmented as libraries and system OSes diverge in their package management. I plan to continue maintaining the install script, but, I do highly suggest that more people try to use the containerized (docker) version. As it should work on basically any 64-bit OS with Docker support. (That means it doesn't work on 32-bit ARM/Rasp Pi.)
 
 ## NOTE: The fixes below are not to be used UNLESS you're having issues, don't run these for no reason, use the distro maintainers version unless there's a reason not to.
 
@@ -18,23 +18,23 @@ sudo apt update
 sudo apt -y -t buster-backports install freerdp2-dev libpulse-dev
 ```
 
-Script for installing Guacamole 1.3.0 on Ubuntu 16.04 or newer (with MySQL, or remote MySQL). It should also work on pure [Debian](https://www.debian.org/), [Raspbian](https://www.raspberrypi.org/downloads/raspbian/), [Linux Mint](https://linuxmint.com/) (18/LMDE 4 or newer) or [Kali Linux](https://www.kali.org/). I have tested this with Debian 10.3.0 (Buster). **If other versions don't work please open an issue.** It is likely due to a required library having a different name.
+Script for installing Guacamole 1.4.0 on Ubuntu 16.04 or newer (with MySQL, or remote MySQL). It should also work on pure [Debian](https://www.debian.org/), [Raspbian](https://www.raspberrypi.org/downloads/raspbian/), [Linux Mint](https://linuxmint.com/) (18/LMDE 4 or newer) or [Kali Linux](https://www.kali.org/). I have tested this with Debian 10.3.0 (Buster). **If other versions don't work please open an issue.** It is likely due to a required library having a different name.
 
 Run script, enter MySQL Root Password and Guacamole User password. Guacamole User is used to connect to the Guacamole Database. Be sure to save these!
 
 The script attempts to install `tomcat9` by default (it will fall back on `tomcat8` **if the available version is 8.5.x or newer**, otherwise it will fall back to `tomcat7`). If you want to manually specify a tomcat version there's a commented out line you can modify. Have at it.
 
-If you're looking to also have NGINX / Let's Encrypt / HTTPS click [HERE](https://github.com/bigredthelogger/guacamole)
+If you're looking to also have NGINX / Let's Encrypt / HTTPS click [HERE](https://github.com/bigredthelogger/guacamole).
 
 ## MFA/2FA
 
-By default the script will not install MFA support (QR code for Google/Microsoft Authenticator, Duo Mobile, etc. or Duo Push), if you do want MFA support you can use the `-t` or `--totp` or for Duo `-d` or `--duo` flags on the command line. Or modify the script variables `installTOTP=true` or `installDuo=true`. **Do not install both**
+By default the script will not install MFA support (QR code for Google/Microsoft Authenticator, Duo Mobile, etc. or Duo Push), if you do want MFA support you can use the `-t` or `--totp` or for Duo `-d` or `--duo` flags on the command line. Or modify the script variables `installTOTP=true` or `installDuo=true`. **Do not install both!**
 
 ## FYI
 
 Here's a cool PowerShell module for using the Guacamole API: https://github.com/UpperM/guacamole-powershell
 
-Does not work if you have MFA turned on (however, you can authenticate via the gui and get a token to use it that way)
+Does not work if you have MFA turned on (however, you can authenticate via the gui and get a token to use it that way).
 
 ## How to Run:
 
@@ -119,7 +119,7 @@ NOTE: Only the switches for MySQL Host, MySQL Port and Guacamole Database are av
 
 ## WARNING
 
-- Upgrading from 0.9.14 or 1.1.0 to 1.3.0 has not been tested, only 1.2.0 to 1.3.0 has been tested.
+- Upgrading from 0.9.14 or 1.1.0 to 1.4.0 has not been tested, only 1.3.0 to 1.4.0 has been tested!
 - Switches have changed and additional ones have been added!
 
 ## How to Run:

--- a/guac-install-server.sh
+++ b/guac-install-server.sh
@@ -4,7 +4,7 @@
 if ! [ $(id -u) = 0 ]; then echo "Please run this script as sudo or root"; exit 1 ; fi
 
 # Version number of Guacamole to install
-GUACVERSION="1.3.0"
+GUACVERSION="1.4.0"
 
 # Different version of Ubuntu/Linux Mint and Debian have different package names...
 source /etc/os-release
@@ -22,7 +22,7 @@ if [[ "${NAME}" == "Ubuntu" ]] || [[ "${NAME}" == "Linux Mint" ]]; then
     fi
 elif [[ "${NAME}" == *"Debian"* ]] || [[ "${NAME}" == *"Raspbian GNU/Linux"* ]] || [[ "${NAME}" == *"Kali GNU/Linux"* ]]  || [[ "${NAME}" == "LMDE" ]]; then
     JPEGTURBO="libjpeg62-turbo-dev"
-    if [[ "${PRETTY_NAME}" == *"stretch"* ]] || [[ "${PRETTY_NAME}" == *"buster"* ]] || [[ "${PRETTY_NAME}" == *"Kali GNU/Linux Rolling"* ]] || [[ "${NAME}" == "LMDE" ]]; then
+    if [[ "${PRETTY_NAME}" == *"bullseye"* ]] || [[ "${PRETTY_NAME}" == *"stretch"* ]] || [[ "${PRETTY_NAME}" == *"buster"* ]] || [[ "${PRETTY_NAME}" == *"Kali GNU/Linux Rolling"* ]] || [[ "${NAME}" == "LMDE" ]]; then
         LIBPNG="libpng-dev"
     else
         LIBPNG="libpng12-dev"
@@ -37,12 +37,12 @@ apt-get -qq update
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y install build-essential libcairo2-dev ${JPEGTURBO} ${LIBPNG} libossp-uuid-dev libavcodec-dev libavformat-dev libavutil-dev \
 libswscale-dev freerdp2-dev libpango1.0-dev libssh2-1-dev libtelnet-dev libvncserver-dev libpulse-dev libssl-dev \
-libvorbis-dev libwebp-dev libwebsockets-dev wget libtool-bin libc-bin
+libvorbis-dev libwebp-dev libwebsockets-dev freerdp2-x11 libtool-bin ghostscript dpkg-dev wget crudini libc-bin
 
 # If apt fails to run completely the rest of this isn't going to work...
 if [ $? != 0 ]; then
     echo "apt-get failed to install all required dependencies."
-    exit
+    exit 1
 fi
 
 # Set SERVER to be the preferred download server from the Apache CDN
@@ -51,9 +51,9 @@ SERVER="http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/${GU
 # Download Guacamole Server
 wget -O guacamole-server-${GUACVERSION}.tar.gz ${SERVER}/source/guacamole-server-${GUACVERSION}.tar.gz
 if [ $? -ne 0 ]; then
-    echo "Failed to download guacamole-server-${GUACVERSION}.tar.gz"
-    echo "${SERVER}/source/guacamole-server-${GUACVERSION}.tar.gz"
-    exit
+    echo -e "${RED}Failed to download guacamole-server-${GUACVERSION}.tar.gz" 1>&2
+    echo -e "${SERVER}/source/guacamole-server-${GUACVERSION}.tar.gz${NC}"
+    exit 1
 else
     # Extract Guacamole Files
     tar -xzf guacamole-server-${GUACVERSION}.tar.gz

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -15,7 +15,7 @@ fi
 
 # Version number of Guacamole to install
 # Homepage ~ https://guacamole.apache.org/releases/
-GUACVERSION="1.3.0"
+GUACVERSION="1.4.0"
 
 # Latest Version of MySQL Connector/J if manual install is required (if libmariadb-java/libmysql-java is not available via apt)
 # Homepage ~ https://dev.mysql.com/downloads/connector/j/
@@ -101,7 +101,7 @@ done
 
 if [[ -z "${installTOTP}" ]] && [[ "${installDuo}" != true ]]; then
     # Prompt the user if they would like to install TOTP MFA, default of no
-    echo -e -n "${CYAN}MFA: Would you like to install TOTP? (y/N): ${NC}"
+    echo -e -n "${CYAN}MFA: Would you like to install TOTP (choose 'N' if you want Duo)? (y/N): ${NC}"
     read PROMPT
     if [[ ${PROMPT} =~ ^[Yy]$ ]]; then
         installTOTP=true

--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -4,7 +4,7 @@
 if ! [ $(id -u) = 0 ]; then echo "Please run this script as sudo or root"; exit 1 ; fi
 
 # Version number of Guacamole to install
-GUACVERSION="1.3.0"
+GUACVERSION="1.4.0"
 
 # Colors to use for output
 YELLOW='\033[1;33m'


### PR DESCRIPTION
Updated for the new version, also updated the guac-install-server.sh a bit, make sure I didn't do anything that would mess it up but I wanted to get it slightly in parity with the regular install script.

Have to review packages yet, I think I saw some potential to add support there, just have to find the time.  I tested the upgrade of my existing 1.3.0 guac to this and it looks to be working fine.