### PR TITLE
Fix RDP Connection issue after upgrade with guac-upgrade.sh from Version 1.2.0 to 1.4.0 to fix existing folders and permissions problems

### DIFF
--- a/guac-upgrade.sh
+++ b/guac-upgrade.sh
@@ -197,6 +197,14 @@ for file in /etc/guacamole/extensions/guacamole-auth-duo*.jar; do
     fi
 done
 
+# Fix for #196
+mkdir -p /usr/sbin/.config/freerdp
+chown daemon:daemon /usr/sbin/.config/freerdp
+
+# Fix for #197
+mkdir -p /var/guacamole
+chown daemon:daemon /var/guacamole
+
 # Start tomcat and Guacamole
 echo -e "${BLUE}Starting tomcat and guacamole...${NC}"
 service ${TOMCAT} start


### PR DESCRIPTION
Fixes upgrade 1.2.0 to 1.4.0 while the directories do not exist after upgrade to version 1.4.0. So FreeRDP can not access this folders with "daemon" user. So I obtained this parts from the guac-install.sh to make RDP work again on upgraded 1.4.0 Version.

# Fix for #196
mkdir -p /usr/sbin/.config/freerdp
chown daemon:daemon /usr/sbin/.config/freerdp

# Fix for #197
mkdir -p /var/guacamole
chown daemon:daemon /var/guacamole