### PR TITLE
Update guac-install.sh

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -15,7 +15,7 @@ fi
 
 # Version number of Guacamole to install
 # Homepage ~ https://guacamole.apache.org/releases/
-GUACVERSION="1.4.0"
+GUACVERSION="1.5.0"
 
 # Latest Version of MySQL Connector/J if manual install is required (if libmariadb-java/libmysql-java is not available via apt)
 # Homepage ~ https://dev.mysql.com/downloads/connector/j/


### PR DESCRIPTION
To install the new version 1.5.0.
Successfully tested under Ubuntu 20.04.5 LTS.